### PR TITLE
Fixing dependency code duplicated when using Bower + Grunt

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,16 +6,14 @@
     "Igor Rafael <igor.rafael@gmail.com>"
   ],
   "description": "Personalized and localized input masks for AngularJS",
-  "main": "angular-input-masks-standalone.min.js",
+  "main": "angular-input-masks-standalone.js",
   "keywords": [
     "angular",
     "input",
     "masks"
   ],
   "dependencies": {
-    "angular": "~1.3.16",
-    "br-validations": "~0.2.4",
-    "string-mask": "~0.2.0"
+    "angular": "~1.3.16"
   },
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
Man, I found two problems with your bower.json when I'm using it with Grunt.

1 -  Your standalone version contains the code for "br-validations" and "string-mask" already, so, when you let that dependencies there and use "grunt wiredep" for example, Grunt includes "angular-input-masks-standalone.min.js", "br-validations.js" and "string-mask.js" on the index.html. In other words, it's duplicated code, once you already have it **inside** standalone file.

2 - It's common, at least in all bower components I use, include the file not minified version, so it's easier to debug local. When you run Grunt, it minify all your javascripts files.

Anyway, nice work!
